### PR TITLE
feat: skip bound checks by iterating

### DIFF
--- a/rizz64/src/lib.rs
+++ b/rizz64/src/lib.rs
@@ -27,19 +27,17 @@ impl Rizz64 {
             return Err(Error::BufferOverflow);
         }
 
-        let mut i = 0;
-        loop {
+        for i in 0..buf.len() {
             let byte = (x & 0x7F) as u8;
             x >>= 7;
+
             let more = (x != 0) as u8;
+            buf[i] = byte | (more << 7);
 
-            unsafe {
-                *buf.get_unchecked_mut(i) = byte | (more << 7);
-            }
-
-            i += 1;
-            if more == 0 { return Ok(i); }
+            if more == 0 { return Ok(i) }
         }
+
+        Err(Error::BufferOverflow)
     }
 
     /// `write_max_u64` creates maximal-encoded variable integers. It does the following:


### PR DESCRIPTION
Instead of running:
```rust
loop {
     unsafe { *buf.get_mut_unchecked(i) = .... } 
}
```

The rust compiler seems to skip this bound check when shoving this into an iterator that is:

```rust
for i in 0..buf.len() {
     // same stuff here
}
```

compiler explorer: https://godbolt.org/z/49P653o9j

### Performance
Running benchmarks indicate significantly faster execution times. 

```sh
Benchmarking Log/write_u64 1152921504606846976: Collecting 10
Log/write_u64 1152921504606846976
                        time:   [321.67 ps 325.25 ps 329.86 ps]
                        change: [-91.933% -91.871% -91.799%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
```

It also seems to beat out the `leb128` crate by significant measures:
```sh
Benchmarking Log/leb128::write::unsigned 1152921504606846976:
Log/leb128::write::unsigned 1152921504606846976
                        time:   [1.6255 ns 1.6417 ns 1.6615 ns]
Found 11 outliers among 100 measurements (11.00%)
  5 (5.00%) high mild
  6 (6.00%) high severe
```

*Note a more robust benchmarking report is needed to fully assert these claims*
